### PR TITLE
Fix /vendor/ support for Go 1.6.

### DIFF
--- a/rego.go
+++ b/rego.go
@@ -80,7 +80,7 @@ func main() {
 				if imp == "C" {
 					continue
 				}
-				impPkg, err := build.Import(imp, "", 0)
+				impPkg, err := build.Import(imp, wd, 0)
 				if err != nil {
 					log.Fatal(err)
 				}


### PR DESCRIPTION
Provide correct working directory to second instance of build.Import. The first one already has wd correctly provided.

/cc @sqs
