### PR TITLE
Use the dir of Go package for resolving dependencies.

### DIFF
--- a/rego.go
+++ b/rego.go
@@ -80,7 +80,7 @@ func main() {
 				if imp == "C" {
 					continue
 				}
-				impPkg, err := build.Import(imp, wd, 0)
+				impPkg, err := build.Import(imp, pkg.Dir, 0)
 				if err != nil {
 					log.Fatal(err)
 				}


### PR DESCRIPTION
This way, rego can be run from any directory and it will work as expected for the target Go package.

This is a followup to #6.

/cc @sqs
