### PR TITLE
README: Fix import path, suggest -u by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rego reinstalls and reruns a Go program when its source files change.
 Usage:
 
 ```
-go get sourcegrah.com/sqs/rego
+go get -u sourcegraph.com.com/sqs/rego
 rego [-v] [-race] import-path [optional args to program...]
 ```
 


### PR DESCRIPTION
Fix typo in the URL.

Suggesting -u is a safer/saner default. It will install/update the library and its dependencies in a predictable way. If users don't wish to update dependencies, they can skip the -u flag.
