### PR TITLE
Update dependency import path.

### DIFF
--- a/rego.go
+++ b/rego.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"golang.org/x/tools/go/buildutil"
-	"gopkg.in/fsnotify.v1"
 )
 
 var (


### PR DESCRIPTION
The import path of this package has changed to `github.com/fsnotify/fsnotify`.

The old import path still works, but that was [an unplanned coincidence](https://github.com/fsnotify/fsnotify/issues/108#issuecomment-185815848). It is no longer officially supported.

See https://github.com/fsnotify/fsnotify/issues/118#issuecomment-185814855 and https://github.com/fsnotify/fsnotify/issues/108#issuecomment-185824561 for source. /cc @nathany

According to https://github.com/fsnotify/fsnotify#api-stability there are future API changes planned, but it should be easy to update usage when that happens, so I don't think vendoring is warranted at this time.
