### PR TITLE
Don't restart when any `write` operation happens

### DIFF
--- a/rego.go
+++ b/rego.go
@@ -189,7 +189,7 @@ func main() {
 
 			go func() {
 				switch ev.Op {
-				case fsnotify.Create, fsnotify.Rename:
+				case fsnotify.Create, fsnotify.Rename, fsnotify.Write:
 					paths := []string{ev.Name}
 
 					// w.Add is non-recursive if the path is a dir, so


### PR DESCRIPTION
If your Go program would create a file of any type using:
`os.OpenFile("name.csv", os.O_CREATE, 0666)` // os.O_CREATE is the important part here
inside the working directory, rego would restart your app, even if the extension was not a `go` file.

fixes #12 

sample Go program that shows the issue:

```
package main

import (
    "fmt"
    "os"
    "time"
)

func main() {
    for x := range time.Tick(1 * time.Second) {
        _ = x
        os.OpenFile("diego.csv", os.O_CREATE|os.O_TRUNC, 0666)
        fmt.Println("2")
    }

}
```

Without the change I propose, rego restarts the app after each tick
