### PR TITLE
Include extraWatches in matchFile

### DIFF
--- a/rego.go
+++ b/rego.go
@@ -89,6 +89,7 @@ func main() {
 		}
 	}
 
+	extraPaths := map[string]bool{}
 	if *extra != "" {
 		for _, pat := range strings.Split(*extra, ",") {
 			matches, err := filepath.Glob(pat)
@@ -96,12 +97,17 @@ func main() {
 				log.Fatal(err)
 			}
 			for _, path := range matches {
+				path, err = filepath.Abs(path)
+				if err != nil {
+					log.Fatal(err)
+				}
 				if *verbose {
 					log.Printf("Watch (extra) %s", path)
 				}
 				if err := w.Add(path); err != nil {
 					log.Fatal(err)
 				}
+				extraPaths[path] = true
 			}
 		}
 	}
@@ -205,7 +211,7 @@ func main() {
 	install <- struct{}{}
 
 	matchFile := func(name string) bool {
-		return filepath.Ext(name) == ".go" && !strings.HasPrefix(filepath.Base(name), ".")
+		return (filepath.Ext(name) == ".go" && !strings.HasPrefix(filepath.Base(name), ".")) || extraPaths[name]
 	}
 
 	for {


### PR DESCRIPTION
Since the introduction of matchFile, extraWatches only worked on go files.
However, the feature is more useful when it watches assets that change and
require a restart. This commit ensures a restart happens in that case.